### PR TITLE
configure Matomo site id for Somn

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -95,7 +95,7 @@ const initAppFn = (envService: EnvironmentService) => {
     BrowserAnimationsModule,
     HttpClientModule,
     NgxMatomoTrackerModule.forRoot({
-      siteId: 5,
+      siteId: 6,
       trackerUrl: 'https://matomo.mmli1.ncsa.illinois.edu/'
     }),
     NgxMatomoRouterModule,


### PR DESCRIPTION
Matomo, which we use for user tracking, needs each app to have a unique ID. This PR updates the Matomo client initialization code to use a new ID generated for Somn in the Matomo admin dashboard.