### PR TITLE
Feat/frontend improvements (2)

### DIFF
--- a/src/app/components/somn/density-plot/density-plot.component.html
+++ b/src/app/components/somn/density-plot/density-plot.component.html
@@ -16,7 +16,7 @@
             <input
                 #minRange
                 type="number"
-                class="absolute appearance-none rounded-md border border-solid p-2"
+                class="absolute appearance-none rounded-md border border-solid p-2 w-12 inline-block"
                 (blur)="updateMinRange(minRange.value)"
                 (keyup.enter)="updateMinRange(minRange.value)"
                 [min]="0"
@@ -25,7 +25,7 @@
             <input
                 #maxRange
                 type="number"
-                class="absolute appearance-none rounded-md border border-solid p-2"
+                class="absolute appearance-none rounded-md border border-solid p-2 w-12 inline-block"
                 (blur)="updateMaxRange(maxRange.value)"
                 (keyup.enter)="updateMaxRange(maxRange.value)"
                 [min]="0"

--- a/src/app/components/somn/density-plot/density-plot.component.ts
+++ b/src/app/components/somn/density-plot/density-plot.component.ts
@@ -336,4 +336,11 @@ export class DensityPlotComponent implements AfterViewInit, OnDestroy {
       }
     });
   }
+
+  exportPNG(filename: string) {
+    this.somnService.exportPNG(
+      this.container.nativeElement.querySelector("svg")!, 
+      `${filename}-density_plot`
+    );
+  }
 }

--- a/src/app/components/somn/heatmap/heatmap.component.ts
+++ b/src/app/components/somn/heatmap/heatmap.component.ts
@@ -12,7 +12,7 @@ import {
 import * as d3 from "d3";
 import { Product, SomnService } from "~/app/services/somn.service";
 
-type HeatmapData = Product & { 
+export type HeatmapData = Product & { 
   solventBase: string;
   isHighlighted: boolean; 
   iid: number 
@@ -116,6 +116,7 @@ export class HeatmapComponent implements AfterViewInit, OnChanges {
           .style("top", (event.y - 40) + "px")
           .style("pointer-events", "none");
       };
+
       let mousedown = (event: MouseEvent, d: any) => {
         if (!d.isHighlighted) {
           return;
@@ -128,7 +129,8 @@ export class HeatmapComponent implements AfterViewInit, OnChanges {
         }
         this.render(data, selectedCells);
         this.selectedCellsChange.emit(selectedCells);
-      }
+      };
+
       let mouseleave = (event: MouseEvent, d: any) => {
         tooltip.style("opacity", 0);
       };

--- a/src/app/components/somn/heatmap/heatmap.component.ts
+++ b/src/app/components/somn/heatmap/heatmap.component.ts
@@ -189,4 +189,12 @@ export class HeatmapComponent implements AfterViewInit, OnChanges {
         .text("Catalyst");
     });
   }
+
+  exportPNG(filename: string) {
+    this.somnService.exportPNG(
+      this.container.nativeElement.querySelector("svg")!, 
+      `${filename}-heatmap`
+    );
+  }
+
 }

--- a/src/app/components/somn/somn-result/somn-result.component.html
+++ b/src/app/components/somn/somn-result/somn-result.component.html
@@ -349,7 +349,13 @@
     </div>
     <div class="flex justify-between mt-2">
         <span class="leading-sm">Reaction Site</span>
-        <span class="font-semibold text-end leading-base inline-block max-w-[200px] break-words">{{ molecule.reactionSite.idx + 1 }}</span>
+        <span class="font-semibold text-end leading-base inline-block max-w-[200px] break-words">
+            {{ 
+                molecule.reactionSitesOptions.length === 1 
+                ? 'Auto detected'
+                : molecule.reactionSite.idx + 1 
+            }}
+        </span>
     </div>
 </ng-template>
 

--- a/src/app/components/somn/somn-result/somn-result.component.html
+++ b/src/app/components/somn/somn-result/somn-result.component.html
@@ -161,7 +161,13 @@
                             class="btn-outline"
                             (click)="clearAllFilters()"
                         >
-                            Clear All
+                            Clear Filters
+                        </button>
+                        <button
+                            class="btn-outline"
+                            (click)="selectedProducts$.next([])"
+                        >
+                            Clear Selections
                         </button>
                     </div>
                 </ng-template>
@@ -250,7 +256,8 @@
                                 #heatmap
                                 id="diagram-heatmap"
                                 [data]="(heatmapData$ | async) || []"
-                                [(selectedCells)]="selectedProducts"
+                                [selectedCells]="(selectedHeatmapCells$ | async) || []"
+                                (selectedCellsChange)="onSelectedHeatmapCellsChange($event)"
                             ></app-heatmap>
                         </div>
                         <p-table
@@ -261,7 +268,9 @@
                             [paginator]="true"
                             [exportFilename]="(exportFileName$ | async) || 'somn-results'"
                             selectionMode="multiple"
-                            [(selection)]="selectedProducts"
+                            [selection]="(selectedTableRows$ | async) || []"
+                            (selectionChange)="onTableSelectionChange($event)"
+                            selectionKeys="iid"
                             dataKey="iid"
                             [rows]="10"
                             [rowsPerPageOptions]="[10, 20, 50]"
@@ -271,9 +280,9 @@
                         >
                             <ng-template pTemplate="header">
                                 <tr>
-                                    <!-- <th style="width: 4rem">
+                                    <th style="width: 4rem">
                                         <p-tableHeaderCheckbox></p-tableHeaderCheckbox>
-                                    </th> -->
+                                    </th>
                                     <th pSortableColumn="catalyst">
                                         Catalyst<p-sortIcon field="catalyst" />
                                     </th>
@@ -289,10 +298,10 @@
                                 </tr>
                             </ng-template>
                             <ng-template pTemplate="body" let-row>
-                                <tr [pSelectableRow]="row">
-                                    <!-- <td>
+                                <tr>
+                                    <td>
                                         <p-tableCheckbox [value]="row"></p-tableCheckbox>
-                                    </td> -->
+                                    </td>
                                     <td (mouseenter)="catalystOverlay.show($event)"
                                         (mouseleave)="catalystOverlay.hide()"
                                     >

--- a/src/app/components/somn/somn-result/somn-result.component.html
+++ b/src/app/components/somn/somn-result/somn-result.component.html
@@ -17,10 +17,11 @@
         <div class="flex items-center gap-2">
             <p-splitButton id="btn-request-options" label="Request Options" styleClass="p-button-outlined" [model]="requestOptions"></p-splitButton>
             <div id="btn-export" class="flex flex-col justify-center">
-                <button class="p-3 px-4 text-white border rounded-md bg-primary" (click)="onExportResults()">
+                <button class="p-3 px-4 text-white border rounded-md bg-primary" (click)="menu.toggle($event)">
                     <i class="mr-2 pi pi-download"></i>
                     <span class="font-semibold">Export</span>                    
                 </button>
+                <p-tieredMenu #menu [model]="exportOptions" [popup]="true" />
             </div>
         </div>
     </div>
@@ -264,16 +265,20 @@
                             #resultsTable
                             id="container-table"
                             [value]="(dataWithColor$ | async) || []"
-                            [columns]="columns"
-                            [paginator]="true"
+
+                            [columns]="exportColumns"
+                            [exportFunction]="exportFunction"
                             [exportFilename]="(exportFileName$ | async) || 'somn-results'"
+
                             selectionMode="multiple"
                             [selection]="(selectedTableRows$ | async) || []"
                             (selectionChange)="onTableSelectionChange($event)"
-                            selectionKeys="iid"
                             dataKey="iid"
+
                             [rows]="10"
                             [rowsPerPageOptions]="[10, 20, 50]"
+                            [paginator]="true"
+
                             class="w-1/2 h-full"
                             tableStyleClass="w-1/2"
                             styleClass="w-full border-l border-solid border-[--surface-d]"

--- a/src/app/services/somn.service.ts
+++ b/src/app/services/somn.service.ts
@@ -188,4 +188,32 @@ export class SomnService {
 
     return legendGradient;
   }
+
+  exportPNG(svgEl: SVGElement, filename: string) {
+    console.log(filename, svgEl.innerHTML);
+    const canvas = document.createElement('canvas');
+    const ctx = canvas.getContext('2d')!;
+    const img = new Image();
+    const svgString = new XMLSerializer().serializeToString(svgEl);
+    const svg = new Blob([svgString], {type: 'image/svg+xml;charset=utf-8'});
+    const url = URL.createObjectURL(svg);
+
+    canvas.height = parseInt(svgEl.getAttribute('height')!);
+    canvas.width = parseInt(svgEl.getAttribute('width')!);
+
+    img.src = url;
+    img.onload = function() {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      ctx.drawImage(img, 0, 0);
+      URL.revokeObjectURL(url);
+
+      const link = document.createElement('a');
+      link.download = `${filename}.png`;
+      link.href = canvas.toDataURL();
+      link.click();
+
+      link.remove();
+      canvas.remove();
+    }
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -10,4 +10,8 @@
     -webkit-appearance: none;
     margin: 0;
   }
+
+  input[type="number"] {
+    -moz-appearance: textfield;
+  }
 }


### PR DESCRIPTION
- In Firefox, the <input>s for the minimum and maximum yield under the distribution plot include the ^ and v clickable arrows to increase or decrease the value. Those are gone now.
- On the results page, if an input has only one reaction site, the result page shows “Reaction Site   auto-detected” instead of "Reaction Site 1"
- Allow multi-select on the table and heatmap.
   - the selected results will always be visible even if they do not satisfy the filter criteria
   - when a result is de-selected and it does not satisfy the search criteria, it will be removed from the list
   - a non-highlighted heatmap cell is not selectable